### PR TITLE
Fix for "unsupported parameter for module: started"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,16 +7,16 @@
   user: name={{ item.app_name }} group={{ item.app_name }} uid={{ item.user_id }} home=/opt/{{ item.app_name }} createhome=no
   with_items: tomcat_apps
   tags: tomcat
-  
+
 - name: Create the directories for the app files
   file: path=/opt/{{ item.app_name }}/ state=directory owner={{ item.app_name }} group={{ item.app_name }} mode=0755
   with_items: tomcat_apps
   tags: tomcat
-  
+
 - name: Download Tomcat
   get_url: url=http://archive.apache.org/dist/tomcat/tomcat-7/v{{ tomcat_version }}/bin/apache-tomcat-{{ tomcat_version }}.tar.gz dest=/opt/
   tags: tomcat
-  
+
 - name: Ensure tar is installed (required by unarchive)
   yum: name=tar state=installed
   tags: tomcat
@@ -25,47 +25,47 @@
   unarchive: src=/opt/apache-tomcat-{{ tomcat_version }}.tar.gz dest=/opt/ copy=no
   with_items: tomcat_apps
   tags: tomcat
-   
+
 - name: Copy Tomcat folder for every app
   shell: cp -R /opt/apache-tomcat-{{ tomcat_version }}/* /opt/{{ item.app_name }}/ creates=/opt/{{ item.app_name }}/bin
   with_items: tomcat_apps
   register: copied_folders
   tags: tomcat
-  
+
 - name: Change ownership of Tomcat app folder
   file: path=/opt/{{ item.0.app_name }}/ state=directory owner={{ item.0.app_name }} group={{ item.0.app_name }} recurse=yes
-  with_together: 
+  with_together:
     - tomcat_apps
     - copied_folders.results
   when: item.1.changed
   tags: tomcat
-  
+
 - name: Configure Tomcat server
   template: src=server.j2 dest=/opt/{{ item.app_name }}/conf/server.xml
   with_items: tomcat_apps
   notify: restart tomcat_apps
   tags: tomcat
-  
+
 - name: Configure Tomcat users
   template: src=tomcat-users.j2 dest=/opt/{{ item.app_name }}/conf/tomcat-users.xml
   with_items: tomcat_apps
   notify: restart tomcat_apps
   tags: tomcat
-  
+
 - name: Install Tomcat init script
   template: src=init_file.j2 dest=/etc/init.d/{{ item.app_name }} mode=0755
   with_items: tomcat_apps
   when: tomcat_daemon is not defined or tomcat_daemon|bool == true
   tags: tomcat
-  
+
 - name: Configure Java memory usage
   template: src=setenv.sh.j2 dest=/opt/{{ item.app_name }}/bin/setenv.sh mode=0755
   with_items: tomcat_apps
   notify: restart tomcat_apps
   tags: tomcat
- 
+
 - name: Enable and start Tomcat apps
-  service: name={{ item.app_name }} started=yes enabled=yes
+  service: name={{ item.app_name }} state=started enabled=yes
   with_items: tomcat_apps
   when: tomcat_daemon is not defined or tomcat_daemon|bool == true
   tags: tomcat


### PR DESCRIPTION
I got an error installing your role due to a small error in the last action. PR is a bugfix. Space trimming assumed to be OK.

TASK: [hostclick.tomcat | Enable and start Tomcat apps] **********************\* 
failed: [web] => (item={'http_port': 8080, 'user_id': 1000, 'app_name': 'tomcat', 'admin_username': 'tomcat', 'xmx': '512M', 'admin_password': 'tomcat', 'server_port': 8006, 'xms': '512M', 'https_port': 8443, 'ajp_port': 8009}) => {"failed": true, "item": {"admin_password": "tomcat", "admin_username": "tomcat", "ajp_port": 8009, "app_name": "tomcat", "http_port": 8080, "https_port": 8443, "server_port": 8006, "user_id": 1000, "xms": "512M", "xmx": "512M"}}
msg: unsupported parameter for module: started

FATAL: all hosts have already failed -- aborting
