### PR TITLE
Fix for #3

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
 - name: restart tomcat_apps
   service: name={{ item.app_name }} state=restarted enabled=yes
-  with_items: tomcat_apps
+  with_items: '{{ tomcat_apps }}'
   when: tomcat_daemon is not defined or tomcat_daemon|bool == true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,16 @@
 - name: Create the group for the app users
   group: name={{ item.app_name }}
-  with_items: tomcat_apps
+  with_items: '{{ tomcat_apps }}'
   tags: tomcat
 
 - name: Create the users for the app files
   user: name={{ item.app_name }} group={{ item.app_name }} uid={{ item.user_id }} home=/opt/{{ item.app_name }} createhome=no
-  with_items: tomcat_apps
+  with_items: '{{ tomcat_apps }}'
   tags: tomcat
 
 - name: Create the directories for the app files
   file: path=/opt/{{ item.app_name }}/ state=directory owner={{ item.app_name }} group={{ item.app_name }} mode=0755
-  with_items: tomcat_apps
+  with_items: '{{ tomcat_apps }}'
   tags: tomcat
 
 - name: Download Tomcat
@@ -23,49 +23,49 @@
 
 - name: Extract Tomcat folder
   unarchive: src=/opt/apache-tomcat-{{ tomcat_version }}.tar.gz dest=/opt/ copy=no
-  with_items: tomcat_apps
+  with_items: '{{ tomcat_apps }}'
   tags: tomcat
 
 - name: Copy Tomcat folder for every app
   shell: cp -R /opt/apache-tomcat-{{ tomcat_version }}/* /opt/{{ item.app_name }}/ creates=/opt/{{ item.app_name }}/bin
-  with_items: tomcat_apps
+  with_items: '{{ tomcat_apps }}'
   register: copied_folders
   tags: tomcat
 
 - name: Change ownership of Tomcat app folder
   file: path=/opt/{{ item.0.app_name }}/ state=directory owner={{ item.0.app_name }} group={{ item.0.app_name }} recurse=yes
   with_together:
-    - tomcat_apps
-    - copied_folders.results
+    - '{{ tomcat_apps }}'
+    - '{{ copied_folders.results }}'
   when: item.1.changed
   tags: tomcat
 
 - name: Configure Tomcat server
   template: src=server.j2 dest=/opt/{{ item.app_name }}/conf/server.xml
-  with_items: tomcat_apps
+  with_items: '{{ tomcat_apps }}'
   notify: restart tomcat_apps
   tags: tomcat
 
 - name: Configure Tomcat users
   template: src=tomcat-users.j2 dest=/opt/{{ item.app_name }}/conf/tomcat-users.xml
-  with_items: tomcat_apps
+  with_items: '{{ tomcat_apps }}'
   notify: restart tomcat_apps
   tags: tomcat
 
 - name: Install Tomcat init script
   template: src=init_file.j2 dest=/etc/init.d/{{ item.app_name }} mode=0755
-  with_items: tomcat_apps
+  with_items: '{{ tomcat_apps }}'
   when: tomcat_daemon is not defined or tomcat_daemon|bool == true
   tags: tomcat
 
 - name: Configure Java memory usage
   template: src=setenv.sh.j2 dest=/opt/{{ item.app_name }}/bin/setenv.sh mode=0755
-  with_items: tomcat_apps
+  with_items: '{{ tomcat_apps }}'
   notify: restart tomcat_apps
   tags: tomcat
 
 - name: Enable and start Tomcat apps
   service: name={{ item.app_name }} state=started enabled=yes
-  with_items: tomcat_apps
+  with_items: '{{ tomcat_apps }}'
   when: tomcat_daemon is not defined or tomcat_daemon|bool == true
   tags: tomcat


### PR DESCRIPTION
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your
playbooks so that the environment value uses the full variable syntax
('{{copied_folders.results}}'). This feature will be removed in a future
release.

Changed syntax in all with_items and with_together clauses.
