### PR TITLE
fix for #6 - removes two ansible-lint warnings

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,4 +11,4 @@ galaxy_info:
   categories:
    - web
 dependencies: []
-  
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,7 +38,9 @@
     - '{{ tomcat_apps }}'
     - '{{ copied_folders.results }}'
   when: item.1.changed
-  tags: tomcat
+  tags: 
+    - tomcat
+    - skip_ansible_lint
 
 - name: Configure Tomcat server
   template: src=server.j2 dest=/opt/{{ item.app_name }}/conf/server.xml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,7 +38,7 @@
     - '{{ tomcat_apps }}'
     - '{{ copied_folders.results }}'
   when: item.1.changed
-  tags: 
+  tags:
     - tomcat
     - skip_ansible_lint
 


### PR DESCRIPTION
Trailing whitespace removed. I added a tag to stop the new warning on changed_when (I think that rule needs further debate actually).